### PR TITLE
Updates python support in marvin_brain

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.3dev
+current_version = 0.3.0dev
 commit = True
 tag = False
 tag_name = {new_version}
@@ -15,4 +15,3 @@ values =
 	alpha
 
 [bumpversion:file:setup.cfg]
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,11 @@
 Marvin's Brain Change Log
 =========================
 
-[0.3.0] - Unreleased
+[0.3.0] - 2022/07/27
 --------------------
 - Drop support for Python 2, Python < 3.8
 - Minimum requirements now requires Python > 3.8
-- Adds testing suite
+- Adds tests to testing suite
 
 [0.2.2] - 2021/11/22
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Marvin's Brain Change Log
 =========================
 
+[0.3.0] - Unreleased
+--------------------
+- Drop support for Python 2, Python < 3.8
+- Minimum requirements now requires Python > 3.8
+- Adds testing suite
+
 [0.2.2] - 2021/11/22
 --------------------
 - Fixed a bug in the API response when the response is not a dictionary

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,21 +25,21 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=2.7
+python_requires = >=3.8
 packages = find:
 package_dir =
 	= python
 install_requires =
-	sdsstools>=0.4.0,<1.0
-	sdss-access>=1.0.0,<2.0
-    flask>=1.1,<2.0
-    flask_classful>=0.14.2,<1.0
-    requests>=2.23.0,<3.0
-    networkx>=2.5,<3.0
-    sqlalchemy>=1.3,<1.4
-    pyyaml>=5.1,<6.0
-    passlib>=1.7.1,<2.0
-    numpy>=1.18,<2.0
+	sdsstools>=0.4.0
+	sdss-access>=2.0
+    flask>=1.1
+    flask_classful>=0.14.2
+    requests>=2.23.0
+    networkx>=2.5
+    sqlalchemy>=1.3
+    pyyaml>=5.1
+    passlib>=1.7.1
+    numpy>=1.18
 
 [options.packages.find]
 where =
@@ -51,32 +51,34 @@ brain =
 
 [options.extras_require]
 extra=
-    msgpack>=1.0,<2.0
-    msgpack_numpy>=0.4,<1.0
-    cachecontrol>=0.12,<1.0
+    msgpack>=1.0
+    msgpack_numpy>=0.4
+    cachecontrol>=0.12
 
 dev =
 	%(docs)s # This forces the docs extras to install (http://bit.ly/2Qz7fzb)
-	ipython>=7.9.0,<8.0
-	matplotlib>=3.1.1,<4.0
-	flake8>=3.7.9,<5.0
-	doc8>=0.8.0,<1.0
-	pytest>=5.2.2,<7.0
-	pytest-cov>=2.8.1,<3.0
-	pytest-sugar>=0.9.2,<1.0
-	pytest-mock>=3.3.1,<4.0
-	isort>=4.3.21,<6.0
-	codecov>=2.0.15,<3.0
-	coverage[toml]>=5.0,<7.0
-	ipdb>=0.12.3,<1.0
+	ipython>=7.9.0
+	matplotlib>=3.1.1
+	flake8>=3.7.9
+	doc8>=0.8.0
+	pytest>=5.2.2
+	pytest-cov>=2.8.1
+	pytest-sugar>=0.9.2
+	pytest-mock>=3.3.1
+	isort>=4.3.21
+	codecov>=2.0.15
+	coverage[toml]>=5.0
+	ipdb>=0.12.3
+	psycopg2>=2.9
+	astropy>5.1
 	# The following are needed because sdsstools[dev] as an extra not always
 	# gets installed. See https://github.com/pypa/pip/issues/4957.
-	invoke>=1.3.0,<2.0
-	twine>=3.1.1,<4.0
-	wheel>=0.33.6,<1.0
+	invoke>=1.3.0
+	twine>=3.1.1
+	wheel>=0.33.6
 docs =
-	Sphinx>=2.1.0,<4.0
-	sphinx_bootstrap_theme>=0.4.12,<1.0
+	Sphinx>=3.1.0
+	sphinx_bootstrap_theme>=0.4.12
 [isort]
 line_length = 79
 sections =

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     pyyaml>=5.1
     passlib>=1.7.1
     numpy>=1.18
+	werkzeug<2.2
 
 [options.packages.find]
 where =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = marvin-brain
-version = 0.2.3dev
+version = 0.3.0dev
 author = Brian Cherinka
 author_email = bcherinka@stsci.edu
 description = Core Marvin Brain for SDSS

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ dev =
 	coverage[toml]>=5.0
 	ipdb>=0.12.3
 	psycopg2>=2.9
-	astropy>5.1
+	astropy>5.0
 	# The following are needed because sdsstools[dev] as an extra not always
 	# gets installed. See https://github.com/pypa/pip/issues/4957.
 	invoke>=1.3.0

--- a/tests/api/test_base.py
+++ b/tests/api/test_base.py
@@ -1,0 +1,38 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+from werkzeug.test import EnvironBuilder
+from flask import Request
+
+from brain.api.base import processRequest
+
+
+def test_process_get():
+    ee = EnvironBuilder(method='GET', path='get',
+                        base_url='https://httpbin.org', query_string='a=1&b=2')
+    rr = Request(ee.get_environ())
+    out = processRequest(rr)
+    assert out.to_dict() == {'a': '1', 'b': '2'}
+
+def test_process_get_param():
+    ee = EnvironBuilder(method='GET', path='get',
+                        base_url='https://httpbin.org', query_string='a=1&b=2')
+    rr = Request(ee.get_environ())
+    out = processRequest(rr, param='a')
+    assert out == '1'
+
+
+def test_process_post_json():
+    ee = EnvironBuilder(method='POST', path='post',
+                        base_url='https://httpbin.org', json={'a':1, 'b':2})
+    rr = Request(ee.get_environ())
+    out = processRequest(rr, as_dict=True)
+    assert out == {'a': 1, 'b': 2}
+
+def test_process_post_form():
+    ee = EnvironBuilder(method='POST', path='post',
+                        base_url='https://httpbin.org', data={'a':1, 'b':2})
+    rr = Request(ee.get_environ())
+    out = processRequest(rr, as_dict=True)
+    assert out.to_dict() == {'a': '1', 'b': '2'}

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -1,0 +1,18 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+from brain.api.query import BrainQueryView
+from brain.api.general import BrainGeneralRequestsView
+
+
+def test_query():
+    b = BrainQueryView()
+    assert b.route_base == '/query/'
+
+
+def test_general():
+    b = BrainQueryView()
+    assert b.route_base == '/general/'
+
+

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -12,7 +12,7 @@ def test_query():
 
 
 def test_general():
-    b = BrainQueryView()
+    b = BrainGeneralRequestsView()
     assert b.route_base == '/general/'
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import pytest
+from brain.core.core import URLMapDict
+from brain.core.exceptions import BrainError
+
+
+def test_urlmap():
+    data = {'a':1, 'b':2, 'c':[1,2,3], 'd': {'e': 1, 'f': 2}}
+    out = URLMapDict(data)
+    assert out == data
+
+def test_urlmap_missing():
+    data = {'a':1, 'b':2, 'c':[1,2,3], 'd': {'e': 1, 'f': 2}}
+    out = URLMapDict(data)
+    with pytest.raises(BrainError, match='Key new not found in urlmap'):
+        out['new']
+
+def test_urlmap_empty():
+    out = URLMapDict({})
+    with pytest.raises(BrainError, match='No URL Map found. Cannot make remote call'):
+        out['new']
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,11 +11,13 @@ def test_urlmap():
     out = URLMapDict(data)
     assert out == data
 
+
 def test_urlmap_missing():
     data = {'a':1, 'b':2, 'c':[1,2,3], 'd': {'e': 1, 'f': 2}}
     out = URLMapDict(data)
     with pytest.raises(BrainError, match='Key new not found in urlmap'):
         out['new']
+
 
 def test_urlmap_empty():
     out = URLMapDict({})

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -1,0 +1,32 @@
+# !usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+
+
+from brain.utils.general.decorators import parseRoutePath, public, check_auth, checkPath
+
+
+def fakefunc(*args, **kwargs):
+    return kwargs
+
+
+def test_public():
+    tt = public(fakefunc)
+    assert hasattr(tt, 'is_public')
+    assert tt.is_public is True
+
+
+def test_checkPath():
+    tt = checkPath(fakefunc)()
+    assert tt == {}
+
+
+def test_parseRoute():
+    kwargs = {'a': 1, 'b': 2, 'path': 'a=b/c=d/e=f'}
+    kk = parseRoutePath(fakefunc)(None, **kwargs)
+    assert kk == {'a': 'b', 'b': 2, 'c': 'd', 'e': 'f'}
+
+
+def test_check_auth():
+    tt = check_auth(fakefunc)()
+    assert tt == {}

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -19,14 +19,7 @@ def test_public():
     assert tt.is_public is True
 
 
-@pytest.mark.skipif(os.path.exists(bconfig._netrc_path), reason='netrc file exists')
-def test_checkPath_fail(netrc):
-    with pytest.raises(BrainError, match='No .netrc file found in your HOME directory!'):
-        checkPath(fakefunc)()
-
-
-@pytest.mark.skipif(not os.path.exists(bconfig._netrc_path), reason='netrc file does not exist')
-def test_checkPath(bestnet):
+def test_checkPath():
     tt = checkPath(fakefunc)()
     assert tt == {}
 
@@ -37,6 +30,13 @@ def test_parseRoute():
     assert kk == {'a': 'b', 'b': 2, 'c': 'd', 'e': 'f'}
 
 
-def test_check_auth():
+@pytest.mark.skipif(os.path.exists(bconfig._netrc_path), reason='netrc file exists')
+def test_check_auth_fail(netrc):
+    with pytest.raises(BrainError, match='No .netrc file found in your HOME directory!'):
+        check_auth(fakefunc)()
+
+
+@pytest.mark.skipif(not os.path.exists(bconfig._netrc_path), reason='netrc file does not exist')
+def test_check_auth(bestnet):
     tt = check_auth(fakefunc)()
     assert tt == {}

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 #
 
-
+import os
+import pytest
+from brain import bconfig
+from brain.core.exceptions import BrainError
 from brain.utils.general.decorators import parseRoutePath, public, check_auth, checkPath
 
 
@@ -16,7 +19,14 @@ def test_public():
     assert tt.is_public is True
 
 
-def test_checkPath():
+@pytest.mark.skipif(os.path.exists(bconfig._netrc_path), reason='netrc file exists')
+def test_checkPath_fail(netrc):
+    with pytest.raises(BrainError, match='No .netrc file found in your HOME directory!'):
+        checkPath(fakefunc)()
+
+
+@pytest.mark.skipif(not os.path.exists(bconfig._netrc_path), reason='netrc file does not exist')
+def test_checkPath(bestnet):
     tt = checkPath(fakefunc)()
     assert tt == {}
 

--- a/tests/utils/test_general.py
+++ b/tests/utils/test_general.py
@@ -11,7 +11,10 @@
 from __future__ import print_function, division, absolute_import
 import os
 import pytest
-from brain.utils.general import getDbMachine, compress_data, uncompress_data
+import yaml
+from brain.utils.general import (getDbMachine, compress_data, uncompress_data, merge,
+                                 convertIvarToErr, inspection_authenticate,
+                                 collaboration_authenticate, get_yaml_loader)
 
 
 class TestGetDbMachine(object):
@@ -55,14 +58,46 @@ class TestCompression(object):
         comp = compress_data(self.data, compress_with=comptype)
         assert comp == expcomp
 
+    def test_base_compression(self):
+        comp = compress_data(self.data)
+        assert comp == '{"a": 1, "b": 2, "c": 3}'
+
     @pytest.mark.parametrize('comptype, expcomp',
                              [('json', '{"a": 1, "b": 2, "c": 3}'),
                               ('msgpack', b'\x83\xa1a\x01\xa1b\x02\xa1c\x03')],
                              ids=['json', 'msgpack'])
     def test_uncompression(self, comptype, expcomp):
         comp = compress_data(self.data, compress_with=comptype)
+        assert comp == expcomp
         uncomp = uncompress_data(comp, uncompress_with=comptype)
         assert uncomp == self.data
 
 
 
+def test_merge():
+    data = merge({'a': 1, 'b': 2}, {'b': 3, 'c': 4})
+    assert data == {'a': 1, 'b': 2, 'c': 4}
+
+
+def test_convertivar():
+    ivar = [127.242065, 122.203674, 123.58732 , 138.0441  , 133.99815 ,
+            127.02346 , 125.417114, 123.45168 , 123.970924, 138.36519, 0., 0. ]
+    exp = [0.08865121, 0.09046027, 0.08995246, 0.08511205, 0.08638744,
+           0.08872746, 0.08929386, 0.09000186, 0.08981318, 0.08501324,
+           0.        , 0.        ]
+    data = convertIvarToErr(ivar)
+    assert exp == pytest.approx(data)
+
+
+def test_inspect_auth():
+    data = inspection_authenticate({}, 'test', 'test')
+    assert data == {'ready': True, 'message': 'Logged in as test. ',
+                    'status': 1, 'membername': 'SDSS User', 'is_valid': True}
+
+def test_collab_auth():
+    data = collaboration_authenticate('test', 'test')
+    assert data == {'is_valid': False, 'status': -1, 'message': "No module named 'collaboration'"}
+
+def test_get_yaml():
+    loader = get_yaml_loader()
+    assert issubclass(loader, yaml.FullLoader)


### PR DESCRIPTION
This PR drops python support <3.8 in marvin_brain.  Also updates the testing suite.   It also relaxes the pinned requirements.