### PR TITLE
Replace deprecated `pkg_resources` function with modern equivalent

### DIFF
--- a/python/brain/utils/general/general.py
+++ b/python/brain/utils/general/general.py
@@ -4,7 +4,7 @@ import datetime
 import numpy as np
 import json
 import yaml
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from brain.core.exceptions import BrainError, BrainWarning
 from hashlib import md5
 from passlib.apache import HtpasswdFile


### PR DESCRIPTION
The `pkg_resources` module was deprecated some time ago, and was fully removed in Python 3.12. Luckily, the `packaging.version` module provides the `parse` function, whose functionality is equivalent to that of `pkg_resources`' ` parse_version` (which AFAICT is the only thing this package used `pkg_resources` for). This PR simply replaces one with the other to maintain compatibility with modern versions of Python, and prevent deprecation warnings in older ones. 